### PR TITLE
Update ice_decrunch.c

### DIFF
--- a/ice_decrunch.c
+++ b/ice_decrunch.c
@@ -4,6 +4,9 @@
 #include <stdio.h>
 #endif
 
+#include<string.h>
+#include<stdio.h>
+
 typedef struct ice_decrunch_state
 {
   char *unpacked_stop;


### PR DESCRIPTION
Added the includes for memcpy and exit to be explicitly declared. At the very least, this makes tinycc build with 0 warnings!