### PR TITLE
Fix error: implicit declaration of function ‘exit’

### DIFF
--- a/ice_decrunch.c
+++ b/ice_decrunch.c
@@ -5,6 +5,7 @@
 #endif
 
 #include<string.h>
+#include <stdlib.h>
 #include<stdio.h>
 
 typedef struct ice_decrunch_state


### PR DESCRIPTION
With GCC 14.2.1. Include ‘<stdlib.h>’ to declare ‘exit’.